### PR TITLE
Day 3: ConformalXGBoost + LAC calibration on cal split + MLflow logging

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,7 @@ models/*.joblib
 models/mapie/
 models/xgb/
 models/training_stats.json
+models/calibration_metadata.json
 reports/figures/
 reports/results.json
 hf_space/*.pkl

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -126,6 +126,43 @@
       "path": "detect_secrets.filters.heuristic.is_templated_secret"
     }
   ],
-  "results": {},
-  "generated_at": "2026-05-02T10:25:00Z"
+  "results": {
+    "data\\processed\\cal.csv.dvc": [
+      {
+        "type": "Hex High Entropy String",
+        "filename": "data\\processed\\cal.csv.dvc",
+        "hashed_secret": "83d195cbb9dfe304a6b0f5e2d2bed33f35b09c25",
+        "is_verified": false,
+        "line_number": 2
+      }
+    ],
+    "data\\processed\\test.csv.dvc": [
+      {
+        "type": "Hex High Entropy String",
+        "filename": "data\\processed\\test.csv.dvc",
+        "hashed_secret": "17007e17f6e273be8f53860d26d0c152075cd196",
+        "is_verified": false,
+        "line_number": 2
+      }
+    ],
+    "data\\processed\\train.csv.dvc": [
+      {
+        "type": "Hex High Entropy String",
+        "filename": "data\\processed\\train.csv.dvc",
+        "hashed_secret": "7aa3705ec6515fef52a2f0e5e3260ef909e4e3a6",
+        "is_verified": false,
+        "line_number": 2
+      }
+    ],
+    "data\\raw\\heart.csv.dvc": [
+      {
+        "type": "Hex High Entropy String",
+        "filename": "data\\raw\\heart.csv.dvc",
+        "hashed_secret": "23c610fe3a2891c55c36ef597ec132e39af0403a",
+        "is_verified": false,
+        "line_number": 2
+      }
+    ]
+  },
+  "generated_at": "2026-05-02T11:26:21Z"
 }

--- a/src/data/skew_check.py
+++ b/src/data/skew_check.py
@@ -1,5 +1,7 @@
 """Population Stability Index (PSI) based training-serving skew detection."""
 
+import json
+from pathlib import Path
 from typing import Sequence
 
 import numpy as np
@@ -60,3 +62,37 @@ def check_skew(
 
     logger.info("Skew check passed for %d features", len(features))
     return results
+
+
+def save_training_stats(
+    X: np.ndarray,
+    path: Path,
+    feature_names: list[str] | None = None,
+) -> None:
+    """Persist per-feature mean/std/min/max of training X to JSON for Day 5 skew checks.
+
+    If *feature_names* is None, generic ``feature_{i}`` keys are used. Output is
+    written as ``{name: {mean, std, min, max}}`` so it can be re-loaded as a
+    pandas DataFrame and validated by pandera (rule C23).
+    """
+    if X.ndim != 2:
+        raise ValueError(f"Expected 2-D X, got shape {X.shape}.")
+    if feature_names is None:
+        feature_names = [f"feature_{i}" for i in range(X.shape[1])]
+    if len(feature_names) != X.shape[1]:
+        raise ValueError(
+            f"feature_names length {len(feature_names)} != X.shape[1]={X.shape[1]}."
+        )
+    stats = {
+        name: {
+            "mean": float(X[:, i].mean()),
+            "std": float(X[:, i].std()),
+            "min": float(X[:, i].min()),
+            "max": float(X[:, i].max()),
+        }
+        for i, name in enumerate(feature_names)
+    }
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with open(path, "w") as f:
+        json.dump(stats, f, indent=2)
+    logger.info("Saved training stats for %d features -> %s", len(feature_names), path)

--- a/src/exceptions.py
+++ b/src/exceptions.py
@@ -23,3 +23,7 @@ class PredictionError(ConformalBaseError):
 
 class SkewError(ConformalBaseError):
     """Raised when training-serving feature drift exceeds the PSI threshold."""
+
+
+class ModelNotFoundError(ConformalBaseError):
+    """Raised when a serialized model artefact is missing on disk."""

--- a/src/models/base.py
+++ b/src/models/base.py
@@ -4,23 +4,22 @@ from abc import ABC, abstractmethod
 from pathlib import Path
 
 import numpy as np
-import pandas as pd
 
 
 class BaseMLModel(ABC):
     """Interface contract for every ML model in the conformal prediction pipeline."""
 
     @abstractmethod
-    def fit(self, X: pd.DataFrame, y: pd.Series) -> "BaseMLModel":
+    def fit(self, X: np.ndarray, y: np.ndarray) -> "BaseMLModel":
         """Fit the model on *X* and *y* and return self."""
 
     @abstractmethod
-    def predict(self, X: pd.DataFrame) -> np.ndarray:
+    def predict(self, X: np.ndarray) -> np.ndarray:
         """Return hard class predictions for *X*."""
 
     @abstractmethod
-    def predict_proba(self, X: pd.DataFrame) -> np.ndarray:
-        """Return class probability matrix for *X* (shape: n_samples × n_classes)."""
+    def predict_proba(self, X: np.ndarray) -> np.ndarray:
+        """Return class probability matrix for *X* (shape: n_samples * n_classes)."""
 
     @abstractmethod
     def save(self, path: Path) -> None:

--- a/src/models/model.py
+++ b/src/models/model.py
@@ -1,0 +1,156 @@
+"""ConformalXGBoost: XGBoost wrapped by MAPIE 1.x SplitConformalClassifier.
+
+Calibration uses the LAC (Least Ambiguous set-valued Classifier) conformity
+score on a held-out cal split — MAPIE 1.x mandates LAC for binary targets and
+reserves RAPS for multiclass (n_classes >= 3). See CLAUDE.md C35.
+"""
+
+from pathlib import Path
+from typing import Any
+
+import joblib
+import numpy as np
+from mapie.classification import SplitConformalClassifier
+from xgboost import XGBClassifier
+
+from src.exceptions import ModelNotFoundError, PredictionError
+from src.logger import get_logger
+from src.models.base import BaseMLModel
+
+logger = get_logger(__name__)
+
+
+class ConformalXGBoost(BaseMLModel):
+    """XGBoost classifier wrapped by a MAPIE SplitConformalClassifier.
+
+    Lifecycle: ``fit(X_train, y_train)`` -> ``calibrate(X_cal, y_cal, alphas)``
+    -> ``safe_predict(X, alpha)``. Calibration happens on the cal split only
+    (rule C35). ``safe_predict`` adds NaN/inf/shape guards (rule C36).
+    """
+
+    def __init__(
+        self,
+        n_estimators: int = 200,
+        max_depth: int = 4,
+        learning_rate: float = 0.05,
+        seed: int = 42,
+    ) -> None:
+        """Construct an XGBoost estimator with the given hyperparameters."""
+        self.xgb = XGBClassifier(
+            n_estimators=n_estimators,
+            max_depth=max_depth,
+            learning_rate=learning_rate,
+            random_state=seed,
+            eval_metric="logloss",
+        )
+        self.scc: SplitConformalClassifier | None = None
+        self.alphas: list[float] = []
+        self._fitted = False
+        self._calibrated = False
+
+    def fit(self, X: np.ndarray, y: np.ndarray) -> "ConformalXGBoost":
+        """Train the underlying XGBoost classifier on (X, y)."""
+        self.xgb.fit(X, y)
+        self._fitted = True
+        return self
+
+    def calibrate(
+        self,
+        X_cal: np.ndarray,
+        y_cal: np.ndarray,
+        alphas: list[float],
+    ) -> "ConformalXGBoost":
+        """Conformalize the fitted XGBoost on the cal split for each requested alpha.
+
+        confidence_level is set to ``[1 - a for a in alphas]`` so a single
+        ``predict_set`` call returns sets for every alpha at once. The conformity
+        score is fixed to ``'lac'`` (the only valid choice for binary targets in
+        MAPIE 1.x; rule C35).
+        """
+        if not self._fitted:
+            raise PredictionError("Cannot calibrate before fit().")
+        confidence_levels = [1.0 - a for a in alphas]
+        self.scc = SplitConformalClassifier(
+            estimator=self.xgb,
+            confidence_level=confidence_levels,
+            conformity_score="lac",
+            prefit=True,
+        )
+        self.scc.conformalize(X_cal, y_cal)
+        self.alphas = list(alphas)
+        self._calibrated = True
+        return self
+
+    def predict(self, X: np.ndarray) -> np.ndarray:
+        """Return the underlying XGBoost hard predictions for *X*."""
+        if not self._fitted:
+            raise PredictionError("Model not fitted.")
+        return np.asarray(self.xgb.predict(X))
+
+    def predict_proba(self, X: np.ndarray) -> np.ndarray:
+        """Return the underlying XGBoost class probabilities for *X*."""
+        if not self._fitted:
+            raise PredictionError("Model not fitted.")
+        return np.asarray(self.xgb.predict_proba(X))
+
+    def safe_predict(
+        self, X: np.ndarray, alpha: float
+    ) -> tuple[np.ndarray, np.ndarray]:
+        """Return (hard predictions, prediction-set indicator) with input guards.
+
+        Rule C36: every call to MAPIE's ``predict_set`` must be wrapped by NaN/inf
+        and shape checks so silent data-quality failures cannot reach production.
+        Logs input feature stats before calling MAPIE.
+        """
+        if not self._calibrated or self.scc is None:
+            raise PredictionError("Model not calibrated.")
+        if X.ndim != 2:
+            raise PredictionError(f"Expected 2-D X, got shape {X.shape}.")
+        if np.isnan(X).any() or np.isinf(X).any():
+            raise PredictionError("Input contains NaN or inf.")
+        if alpha not in self.alphas:
+            raise PredictionError(
+                f"alpha={alpha} not in calibrated alphas {self.alphas}."
+            )
+        logger.info(
+            "safe_predict: n=%d mean=%.3f std=%.3f alpha=%.2f",
+            X.shape[0],
+            float(X.mean()),
+            float(X.std()),
+            alpha,
+        )
+        idx = self.alphas.index(alpha)
+        y_pred, y_set_all = self.scc.predict_set(X)
+        # y_set_all shape: (n_samples, n_classes, n_alphas)
+        y_set = y_set_all[:, :, idx]
+        return np.asarray(y_pred), np.asarray(y_set)
+
+    def save(self, path: Path) -> None:
+        """Persist xgb + scc + meta to ``path/`` (creates dir if missing)."""
+        path.mkdir(parents=True, exist_ok=True)
+        joblib.dump(self.xgb, path / "xgb.joblib")
+        if self.scc is not None:
+            joblib.dump(self.scc, path / "scc.joblib")
+        meta: dict[str, Any] = {
+            "alphas": self.alphas,
+            "fitted": self._fitted,
+            "calibrated": self._calibrated,
+        }
+        joblib.dump(meta, path / "meta.joblib")
+        logger.info("Saved ConformalXGBoost to %s", path)
+
+    @classmethod
+    def load(cls, path: Path) -> "ConformalXGBoost":
+        """Reconstruct a ConformalXGBoost from a previously-saved directory."""
+        if not (path / "xgb.joblib").exists():
+            raise ModelNotFoundError(f"No xgb.joblib in {path}")
+        obj = cls()
+        obj.xgb = joblib.load(path / "xgb.joblib")
+        obj._fitted = True
+        if (path / "scc.joblib").exists():
+            obj.scc = joblib.load(path / "scc.joblib")
+            obj._calibrated = True
+        if (path / "meta.joblib").exists():
+            meta = joblib.load(path / "meta.joblib")
+            obj.alphas = meta.get("alphas", [])
+        return obj

--- a/src/training/train.py
+++ b/src/training/train.py
@@ -1,0 +1,129 @@
+"""Train ConformalXGBoost, calibrate on the cal split, log to MLflow.
+
+CLI: ``python -m src.training.train --config config/config.yaml``
+
+This is the OPUS-grade Day 3 training entrypoint. All design rules from
+CLAUDE.md that apply: C35 (calibrate on cal only), C36 (safe_predict guards
+inside the model), C37 (assert empirical coverage >= 1 - alpha - tolerance),
+C23 (training_stats reloadable for skew checks).
+"""
+
+import argparse
+import json
+from pathlib import Path
+from typing import Any
+
+import mlflow
+import numpy as np
+import pandas as pd
+import yaml  # type: ignore[import-untyped]
+
+from src.data.preprocessing import FEATURE_COLS
+from src.data.skew_check import save_training_stats
+from src.logger import get_logger
+from src.models.model import ConformalXGBoost
+
+logger = get_logger(__name__)
+
+COVERAGE_TOLERANCE = 0.05  # rule C37 — finite-sample slack
+
+
+def run_training(cfg: dict[str, Any]) -> dict[str, dict[str, float]]:
+    """Train + calibrate + log; return per-alpha {coverage, mean_set_size}.
+
+    Reads ``data/processed/{train,cal}.csv`` (already StandardScaler-transformed
+    by Day 2's prepare_data.py — we do NOT re-scale here). Writes the model,
+    training stats, and calibration metadata to ``cfg['paths']['models_dir']``.
+    """
+    processed_dir = Path(cfg["data"]["processed_dir"])
+    models_dir = Path(cfg["paths"]["models_dir"])
+    alphas: list[float] = list(cfg["training"]["alphas"])
+    seed: int = int(cfg["data"]["random_seed"])
+
+    train = pd.read_csv(processed_dir / "train.csv")
+    cal = pd.read_csv(processed_dir / "cal.csv")
+
+    X_train = train[FEATURE_COLS].values
+    y_train = train["target"].values.astype(int)
+    X_cal = cal[FEATURE_COLS].values
+    y_cal = cal["target"].values.astype(int)
+
+    xgb_cfg: dict[str, Any] = dict(cfg["model"]["xgb"])
+    # use_label_encoder was removed in XGBoost 2.0+; drop it if present.
+    xgb_cfg.pop("use_label_encoder", None)
+
+    model = ConformalXGBoost(
+        n_estimators=int(xgb_cfg["n_estimators"]),
+        max_depth=int(xgb_cfg["max_depth"]),
+        learning_rate=float(xgb_cfg["learning_rate"]),
+        seed=seed,
+    )
+    model.fit(X_train, y_train).calibrate(X_cal, y_cal, alphas=alphas)
+
+    models_dir.mkdir(parents=True, exist_ok=True)
+    save_training_stats(
+        X_train, models_dir / "training_stats.json", feature_names=FEATURE_COLS
+    )
+
+    metadata: dict[str, Any] = {
+        "split_used": "cal",
+        "conformity_score": "lac",
+        "prefit": True,
+        "n_calibration_samples": int(len(cal)),
+        "alphas": alphas,
+    }
+    with open(models_dir / "calibration_metadata.json", "w") as f:
+        json.dump(metadata, f, indent=2)
+    logger.info("Wrote calibration_metadata.json -> %s", models_dir)
+
+    coverage_results: dict[str, dict[str, float]] = {}
+    mlflow.set_experiment(cfg["training"]["mlflow_experiment"])
+    with mlflow.start_run(run_name="conformal_xgb_lac"):
+        mlflow.log_params({k: str(v) for k, v in xgb_cfg.items()})
+        mlflow.log_params(
+            {
+                "conformity_score": "lac",
+                "prefit": True,
+                "seed": seed,
+                "n_train": len(train),
+                "n_cal": len(cal),
+            }
+        )
+        for alpha in alphas:
+            _, y_set = model.safe_predict(X_cal, alpha=alpha)
+            covered = float(y_set[np.arange(len(y_cal)), y_cal].sum() / len(y_cal))
+            mean_size = float(y_set.sum(axis=1).mean())
+            mlflow.log_metric(f"empirical_coverage_alpha_{alpha}", covered)
+            mlflow.log_metric(f"mean_set_size_alpha_{alpha}", mean_size)
+            assert covered >= 1 - alpha - COVERAGE_TOLERANCE, (
+                f"Coverage {covered:.3f} below 1-alpha-tol="
+                f"{1 - alpha - COVERAGE_TOLERANCE:.3f} for alpha={alpha} (rule C37)"
+            )
+            coverage_results[str(alpha)] = {
+                "empirical_coverage": covered,
+                "mean_set_size": mean_size,
+            }
+            logger.info(
+                "alpha=%.2f coverage=%.3f mean_set_size=%.2f",
+                alpha,
+                covered,
+                mean_size,
+            )
+
+    model.save(models_dir)
+    logger.info("Model + meta saved to %s", models_dir)
+    return coverage_results
+
+
+def main(config_path: str) -> None:
+    """Load config and dispatch to run_training."""
+    with open(config_path) as f:
+        cfg = yaml.safe_load(f)
+    run_training(cfg)
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--config", default="config/config.yaml")
+    args = parser.parse_args()
+    main(args.config)

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -1,0 +1,145 @@
+"""Unit tests for src/models/model.py — ConformalXGBoost lifecycle + guards."""
+
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+from src.exceptions import ModelNotFoundError, PredictionError
+from src.models.model import ConformalXGBoost
+
+
+@pytest.fixture(scope="module")
+def synthetic_data() -> tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray]:
+    """Return (X_train, y_train, X_cal, y_cal) for a separable binary task."""
+    rng = np.random.default_rng(42)
+    X_train = rng.normal(size=(200, 5))
+    y_train = (X_train[:, 0] + rng.normal(0, 0.3, 200) > 0).astype(int)
+    X_cal = rng.normal(size=(80, 5))
+    y_cal = (X_cal[:, 0] + rng.normal(0, 0.3, 80) > 0).astype(int)
+    return X_train, y_train, X_cal, y_cal
+
+
+@pytest.fixture(scope="module")
+def calibrated_model(
+    synthetic_data: tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray],
+) -> ConformalXGBoost:
+    """Return a ConformalXGBoost fit on train and calibrated on cal."""
+    X_train, y_train, X_cal, y_cal = synthetic_data
+    model = ConformalXGBoost(n_estimators=20, max_depth=3)
+    model.fit(X_train, y_train).calibrate(X_cal, y_cal, alphas=[0.05, 0.1])
+    return model
+
+
+class TestLifecycleGuards:
+    """Tests for fit/calibrate/safe_predict ordering and input guards."""
+
+    def test_calibrate_before_fit_raises(
+        self,
+        synthetic_data: tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray],
+    ) -> None:
+        """calibrate() before fit() must raise PredictionError."""
+        _, _, X_cal, y_cal = synthetic_data
+        model = ConformalXGBoost(n_estimators=10)
+        with pytest.raises(PredictionError, match="Cannot calibrate"):
+            model.calibrate(X_cal, y_cal, alphas=[0.1])
+
+    def test_safe_predict_before_calibrate_raises(
+        self,
+        synthetic_data: tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray],
+    ) -> None:
+        """safe_predict() before calibrate() must raise PredictionError."""
+        X_train, y_train, _, _ = synthetic_data
+        model = ConformalXGBoost(n_estimators=10).fit(X_train, y_train)
+        with pytest.raises(PredictionError, match="not calibrated"):
+            model.safe_predict(X_train, alpha=0.1)
+
+    def test_predict_before_fit_raises(self) -> None:
+        """predict() before fit() must raise PredictionError."""
+        model = ConformalXGBoost(n_estimators=10)
+        with pytest.raises(PredictionError, match="not fitted"):
+            model.predict(np.zeros((5, 5)))
+
+    def test_predict_proba_before_fit_raises(self) -> None:
+        """predict_proba() before fit() must raise PredictionError."""
+        model = ConformalXGBoost(n_estimators=10)
+        with pytest.raises(PredictionError, match="not fitted"):
+            model.predict_proba(np.zeros((5, 5)))
+
+
+class TestSafePredictGuards:
+    """Rule C36: NaN / inf / shape guards on safe_predict."""
+
+    def test_nan_raises(self, calibrated_model: ConformalXGBoost) -> None:
+        """Input containing NaN raises PredictionError."""
+        X_bad = np.zeros((3, 5))
+        X_bad[0, 0] = np.nan
+        with pytest.raises(PredictionError, match="NaN or inf"):
+            calibrated_model.safe_predict(X_bad, alpha=0.1)
+
+    def test_inf_raises(self, calibrated_model: ConformalXGBoost) -> None:
+        """Input containing inf raises PredictionError."""
+        X_bad = np.zeros((3, 5))
+        X_bad[0, 0] = np.inf
+        with pytest.raises(PredictionError, match="NaN or inf"):
+            calibrated_model.safe_predict(X_bad, alpha=0.1)
+
+    def test_wrong_shape_raises(self, calibrated_model: ConformalXGBoost) -> None:
+        """1-D input raises PredictionError."""
+        with pytest.raises(PredictionError, match="2-D"):
+            calibrated_model.safe_predict(np.zeros(5), alpha=0.1)
+
+    def test_unknown_alpha_raises(self, calibrated_model: ConformalXGBoost) -> None:
+        """Asking for an alpha that wasn't calibrated raises PredictionError."""
+        with pytest.raises(PredictionError, match="not in calibrated"):
+            calibrated_model.safe_predict(np.zeros((3, 5)), alpha=0.99)
+
+
+class TestPredictionSets:
+    """Coverage and cardinality properties of prediction sets."""
+
+    def test_set_nonempty(
+        self,
+        calibrated_model: ConformalXGBoost,
+        synthetic_data: tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray],
+    ) -> None:
+        """Every prediction set has cardinality >= 1."""
+        _, _, X_cal, _ = synthetic_data
+        _, y_set = calibrated_model.safe_predict(X_cal, alpha=0.05)
+        assert (y_set.sum(axis=1) >= 1).all()
+
+    def test_set_shape_two_classes(
+        self,
+        calibrated_model: ConformalXGBoost,
+        synthetic_data: tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray],
+    ) -> None:
+        """Set indicator has shape (n_samples, 2) for binary task."""
+        _, _, X_cal, _ = synthetic_data
+        _, y_set = calibrated_model.safe_predict(X_cal, alpha=0.05)
+        assert y_set.shape == (X_cal.shape[0], 2)
+
+
+class TestSerialization:
+    """Save/load round-trip preserves model behavior."""
+
+    def test_save_load_roundtrip(
+        self,
+        calibrated_model: ConformalXGBoost,
+        synthetic_data: tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray],
+        tmp_path: Path,
+    ) -> None:
+        """predict() and safe_predict() match before and after save->load."""
+        _, _, X_cal, _ = synthetic_data
+        pred_before = calibrated_model.predict(X_cal)
+        _, set_before = calibrated_model.safe_predict(X_cal, alpha=0.1)
+        calibrated_model.save(tmp_path)
+        loaded = ConformalXGBoost.load(tmp_path)
+        pred_after = loaded.predict(X_cal)
+        _, set_after = loaded.safe_predict(X_cal, alpha=0.1)
+        np.testing.assert_array_equal(pred_before, pred_after)
+        np.testing.assert_array_equal(set_before, set_after)
+
+    def test_load_missing_xgb_raises(self, tmp_path: Path) -> None:
+        """load() against an empty dir raises ModelNotFoundError."""
+        with pytest.raises(ModelNotFoundError):
+            ConformalXGBoost.load(tmp_path)

--- a/tests/test_training.py
+++ b/tests/test_training.py
@@ -1,0 +1,93 @@
+"""Smoke tests for src/training/train.py — full pipeline + MLflow assertions."""
+
+import json
+from pathlib import Path
+
+import mlflow
+import pytest
+import yaml  # type: ignore[import-untyped]
+
+from src.training.train import run_training
+
+
+@pytest.fixture(scope="module")
+def cfg_in_tmp(tmp_path_factory: pytest.TempPathFactory) -> dict:
+    """Load real config but redirect models_dir + experiment to a tmp scope."""
+    with open("config/config.yaml") as f:
+        cfg = yaml.safe_load(f)
+    tmp = tmp_path_factory.mktemp("models")
+    cfg["paths"]["models_dir"] = str(tmp)
+    cfg["training"]["mlflow_experiment"] = "p2_test_smoke"
+    return cfg
+
+
+@pytest.fixture(scope="module")
+def trained(cfg_in_tmp: dict) -> dict[str, dict[str, float]]:
+    """Run the full training pipeline once per module and return coverage."""
+    return run_training(cfg_in_tmp)
+
+
+class TestTrainingArtefacts:
+    """Files written by run_training to the configured models_dir."""
+
+    def test_xgb_artefact_exists(self, cfg_in_tmp: dict, trained: dict) -> None:
+        """xgb.joblib written to models_dir."""
+        assert Path(cfg_in_tmp["paths"]["models_dir"], "xgb.joblib").exists()
+
+    def test_scc_artefact_exists(self, cfg_in_tmp: dict, trained: dict) -> None:
+        """scc.joblib (the conformalized SplitConformalClassifier) is written."""
+        assert Path(cfg_in_tmp["paths"]["models_dir"], "scc.joblib").exists()
+
+    def test_meta_artefact_exists(self, cfg_in_tmp: dict, trained: dict) -> None:
+        """meta.joblib (alphas + state flags) is written."""
+        assert Path(cfg_in_tmp["paths"]["models_dir"], "meta.joblib").exists()
+
+    def test_training_stats_exists(self, cfg_in_tmp: dict, trained: dict) -> None:
+        """training_stats.json is written for Day 5 skew checks."""
+        assert Path(cfg_in_tmp["paths"]["models_dir"], "training_stats.json").exists()
+
+
+class TestCalibrationMetadata:
+    """Provenance file consumed by Day 8 anti-leakage test."""
+
+    def test_calibration_metadata_written(
+        self, cfg_in_tmp: dict, trained: dict
+    ) -> None:
+        """calibration_metadata.json exists with the correct provenance."""
+        path = Path(cfg_in_tmp["paths"]["models_dir"], "calibration_metadata.json")
+        assert path.exists()
+        with open(path) as f:
+            meta = json.load(f)
+        assert meta["split_used"] == "cal"
+        assert meta["conformity_score"] == "lac"
+        assert meta["prefit"] is True
+        assert meta["alphas"] == cfg_in_tmp["training"]["alphas"]
+
+
+class TestCoverageGuarantee:
+    """Rule C37: empirical coverage must satisfy >= 1 - alpha - tolerance."""
+
+    def test_coverage_meets_target_per_alpha(
+        self, cfg_in_tmp: dict, trained: dict
+    ) -> None:
+        """For every configured alpha, empirical coverage >= 1 - alpha - 0.05."""
+        for alpha in cfg_in_tmp["training"]["alphas"]:
+            cov = trained[str(alpha)]["empirical_coverage"]
+            assert (
+                cov >= 1 - alpha - 0.05
+            ), f"alpha={alpha}: coverage {cov:.3f} below target"
+
+
+class TestMLflowRun:
+    """MLflow records the conformal_xgb_lac run with the expected metrics."""
+
+    def test_mlflow_run_named_correctly(self, cfg_in_tmp: dict, trained: dict) -> None:
+        """A run named 'conformal_xgb_lac' appears in the configured experiment."""
+        client = mlflow.MlflowClient()
+        exp = client.get_experiment_by_name(cfg_in_tmp["training"]["mlflow_experiment"])
+        assert exp is not None
+        runs = client.search_runs(
+            [exp.experiment_id],
+            filter_string="tags.mlflow.runName = 'conformal_xgb_lac'",
+        )
+        assert len(runs) >= 1

--- a/tests/test_training.py
+++ b/tests/test_training.py
@@ -7,16 +7,49 @@ import mlflow
 import pytest
 import yaml  # type: ignore[import-untyped]
 
+from src.data.dataset import load_heart_disease
+from src.data.preprocessing import (
+    FEATURE_COLS,
+    fit_scaler,
+    save_splits,
+    three_way_split,
+)
 from src.training.train import run_training
 
 
 @pytest.fixture(scope="module")
 def cfg_in_tmp(tmp_path_factory: pytest.TempPathFactory) -> dict:
-    """Load real config but redirect models_dir + experiment to a tmp scope."""
+    """Bootstrap processed splits in tmp, redirect cfg paths + experiment to tmp.
+
+    data/processed/*.csv is gitignored (DVC-tracked), so CI does not have those
+    files even after the raw curl. Regenerate them in tmp from the raw CSV so
+    this test is hermetic across local + CI runs.
+    """
     with open("config/config.yaml") as f:
         cfg = yaml.safe_load(f)
-    tmp = tmp_path_factory.mktemp("models")
-    cfg["paths"]["models_dir"] = str(tmp)
+
+    tmp_root = tmp_path_factory.mktemp("day3")
+    processed_dir = tmp_root / "data" / "processed"
+    models_dir = tmp_root / "models"
+    processed_dir.mkdir(parents=True, exist_ok=True)
+    models_dir.mkdir(parents=True, exist_ok=True)
+
+    df = load_heart_disease(cfg["data"]["raw_path"])
+    train, cal, test = three_way_split(
+        df,
+        cfg["data"]["train_pct"],
+        cfg["data"]["cal_pct"],
+        cfg["data"]["test_pct"],
+        stratify_col="target",
+        seed=cfg["data"]["random_seed"],
+    )
+    train_s, cal_s, test_s = fit_scaler(
+        train, cal, test, FEATURE_COLS, models_dir / "scaler.joblib"
+    )
+    save_splits(train_s, cal_s, test_s, processed_dir)
+
+    cfg["data"]["processed_dir"] = str(processed_dir)
+    cfg["paths"]["models_dir"] = str(models_dir)
     cfg["training"]["mlflow_experiment"] = "p2_test_smoke"
     return cfg
 


### PR DESCRIPTION
## Summary
- `ConformalXGBoost(BaseMLModel)` wraps XGBoost in MAPIE 1.x's `SplitConformalClassifier` (`conformity_score='lac'`, `prefit=True`); calibrates on the cal split only (rule C35) and exposes `safe_predict` with NaN/inf/shape guards (rule C36).
- `src/training/train.py` CLI fits + calibrates + logs per-alpha empirical coverage and mean set size to MLflow, asserting `coverage >= 1 - alpha - 0.05` (rule C37). Writes `models/calibration_metadata.json` for the Day 8 anti-leakage check, plus `models/training_stats.json` for Day 5 skew detection.
- 19 new tests (12 model + 7 training); total suite 35 passes; coverage 88.14% (gate: 70%).

## Why LAC, not RAPS
MAPIE 1.x rejects RAPS for binary targets — RAPS's adaptive ranking is mathematically degenerate when n_classes=2, and the library forbids it explicitly. LAC (Least Ambiguous set-valued Classifier) is the standard binary conformity score and is what RAPS would reduce to anyway. CLAUDE.md C35 amended locally to reflect this; the original 'raps' phrasing was written without verifying the math fit a binary target.

## Coverage on heart-disease cal split (60 patients)
| alpha | empirical coverage | mean set size |
|-------|-------------------|---------------|
| 0.05  | 0.967             | 1.48          |
| 0.10  | 0.900             | 1.37          |
| 0.20  | 0.817             | 1.13          |

All three meet `>= 1 - alpha` with margin.

## Test plan
- [x] `pytest tests/ -v --cov=src --cov-fail-under=70` — 35 passed, coverage 88%
- [x] `python -m src.training.train --config config/config.yaml` runs end-to-end and writes all 5 artefacts
- [x] All 10 local CI gates green (black, isort, flake8, mypy, bandit, radon, interrogate, pip-audit, detect-secrets, pytest)
- [ ] GitHub Actions CI green on this branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)