### PR TITLE
chore(deps): bundle 7 dependabot bumps

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,10 +14,10 @@ jobs:
   lint-test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Set up Python 3.12
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.12"
           cache: "pip"

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,11 +1,11 @@
 black==24.10.0
 isort==5.13.2
 flake8==7.1.1
-mypy==1.13.0
+mypy==1.20.2
 bandit==1.8.3
 radon==6.0.1
 interrogate==1.7.0
-pip-audit==2.8.0
+pip-audit==2.10.0
 detect-secrets==1.5.0
 pytest==8.3.4
 pytest-cov==6.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,12 +1,12 @@
 pandas>=2.2.0
 numpy>=1.26.0
 scikit-learn>=1.4.0
-xgboost>=2.0.0
-joblib>=1.3.0
+xgboost>=3.2.0
+joblib>=1.5.3
 mlflow>=2.14.0
 pandera>=0.20.0
 python-json-logger>=2.0.7
-PyYAML>=6.0.1
+PyYAML>=6.0.3
 mapie>=0.8.6
 pydantic>=2.7.0
 fastapi>=0.111.0


### PR DESCRIPTION
## Summary
Bundles 7 dependabot PRs (#1-#7) into one to avoid cascading rebases on requirements files. All 7 originals had green CI individually after rebase against current main.

| dep | from | to | source |
|-----|------|----|--------|
| actions/checkout | v4 | v6 | PR #1 |
| actions/setup-python | v5 | v6 | PR #2 |
| mypy | 1.13.0 | 1.20.2 | PR #3 |
| joblib | >=1.3.0 | >=1.5.3 | PR #4 |
| pip-audit | 2.8.0 | 2.10.0 | PR #5 |
| PyYAML | >=6.0.1 | >=6.0.3 | PR #6 |
| xgboost | >=2.0.0 | >=3.2.0 | PR #7 |

setup-python v6 also resolves the Node 20 deprecation warning ahead of GitHub's June 2026 cutoff.

## Test plan
- [x] All 10 local push gates green with new versions installed
- [x] mypy 1.20.2 finds no new errors on src/
- [x] pip-audit 2.10 reports no known vulnerabilities
- [x] pytest 35/35 with coverage 90.57% (gate 70%)
- [ ] GitHub Actions CI green on this branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)