### PR TITLE
Day 4 PR3: Mondrian group coverage + parity tests

### DIFF
--- a/src/evaluation/evaluate.py
+++ b/src/evaluation/evaluate.py
@@ -21,13 +21,15 @@ import mlflow
 import pandas as pd
 import yaml  # type: ignore[import-untyped]
 
-from src.data.preprocessing import FEATURE_COLS
+from src.data.dataset import load_heart_disease
+from src.data.preprocessing import FEATURE_COLS, three_way_split
 from src.evaluation.coverage import (
     compute_per_alpha_coverage,
     plot_coverage_bar,
     plot_set_sizes_hist,
 )
 from src.evaluation.method_compare import compare_methods, plot_method_comparison
+from src.evaluation.mondrian import group_coverage, parity_test, plot_group_coverage
 from src.logger import get_logger
 from src.models.model import ConformalXGBoost
 
@@ -86,6 +88,24 @@ def run_evaluation(cfg: dict[str, Any]) -> dict[str, Any]:
         results["method_comparison"],
         figures_dir / "method_comparison_set_sizes.png",
     )
+
+    # Section C — Mondrian group coverage. Re-derive the raw test split from
+    # the raw CSV (deterministic with the same seed) so we have unscaled
+    # sex/age columns for grouping; the scaled X_test still feeds the model.
+    primary_alpha = float(alphas[1]) if len(alphas) >= 2 else float(alphas[0])
+    raw_df = load_heart_disease(cfg["data"]["raw_path"])
+    _, _, raw_test = three_way_split(
+        raw_df,
+        cfg["data"]["train_pct"],
+        cfg["data"]["cal_pct"],
+        cfg["data"]["test_pct"],
+        stratify_col="target",
+        seed=int(cfg["data"]["random_seed"]),
+    )
+    gc = group_coverage(model, raw_test, X_test, primary_alpha)
+    gc["parity"] = parity_test(model, raw_test, X_test, primary_alpha)
+    results["group_coverage"] = gc
+    plot_group_coverage(gc, primary_alpha, figures_dir / "group_coverage.png")
 
     # Persist — merge into existing reports/results.json so baseline_xgb stays.
     out_path = reports_dir / "results.json"

--- a/src/evaluation/evaluate.py
+++ b/src/evaluation/evaluate.py
@@ -27,6 +27,7 @@ from src.evaluation.coverage import (
     plot_coverage_bar,
     plot_set_sizes_hist,
 )
+from src.evaluation.method_compare import compare_methods, plot_method_comparison
 from src.logger import get_logger
 from src.models.model import ConformalXGBoost
 
@@ -50,7 +51,13 @@ def run_evaluation(cfg: dict[str, Any]) -> dict[str, Any]:
     reports_dir.mkdir(parents=True, exist_ok=True)
     alphas: list[float] = list(cfg["training"]["alphas"])
 
+    train = pd.read_csv(processed_dir / "train.csv")
+    cal = pd.read_csv(processed_dir / "cal.csv")
     test = pd.read_csv(processed_dir / "test.csv")
+    X_train = train[FEATURE_COLS].values
+    y_train = train["target"].values.astype(int)
+    X_cal = cal[FEATURE_COLS].values
+    y_cal = cal["target"].values.astype(int)
     X_test = test[FEATURE_COLS].values
     y_test = test["target"].values.astype(int)
 
@@ -62,6 +69,23 @@ def run_evaluation(cfg: dict[str, Any]) -> dict[str, Any]:
     results["coverage"] = compute_per_alpha_coverage(model, X_test, y_test, alphas)
     plot_coverage_bar(results["coverage"], figures_dir / "coverage_guarantee.png")
     plot_set_sizes_hist(model, X_test, alphas, figures_dir / "set_sizes.png")
+
+    # Section B — LAC vs APS vs CV+ method comparison (RAPS skipped per C35).
+    results["method_comparison"] = compare_methods(
+        X_train=X_train,
+        y_train=y_train,
+        X_cal=X_cal,
+        y_cal=y_cal,
+        X_test=X_test,
+        y_test=y_test,
+        alphas=alphas,
+        xgb_params=cfg["model"]["xgb"],
+        seed=int(cfg["data"]["random_seed"]),
+    )
+    plot_method_comparison(
+        results["method_comparison"],
+        figures_dir / "method_comparison_set_sizes.png",
+    )
 
     # Persist — merge into existing reports/results.json so baseline_xgb stays.
     out_path = reports_dir / "results.json"

--- a/src/evaluation/method_compare.py
+++ b/src/evaluation/method_compare.py
@@ -1,0 +1,194 @@
+"""Compare conformal methods on the test split: Split CP vs CV+ (5) vs CV+ (10).
+
+CLAUDE.md C35 forbids any conformity score other than LAC for binary targets
+(MAPIE 1.x rejects APS/RAPS at runtime with a `ValueError: Invalid conformity
+score for binary target. The only valid score is 'lac'`). The interesting
+axis to vary is therefore the **splitting strategy**, not the score:
+
+* **Split CP (LAC, prefit XGB)** — the production model. Calibrates on a
+  single 20% cal split. Cheap; one model trained.
+* **Cross-CP, k=5 (LAC, Jackknife+ flavour)** — `CrossConformalClassifier`
+  with cv=5. Uses every training row for both fitting and calibration via
+  K-fold; trains 5 models. More data-efficient on small samples (n=303
+  here) at the cost of K-fold compute.
+* **Cross-CP, k=10 (LAC)** — same as above with cv=10. Closer to
+  leave-one-out; smaller per-fold variance, more compute.
+
+For every (method, alpha) pair we report empirical coverage and mean set
+size on the test split. The grouped bar chart visualises the trade-off:
+all three methods clear the 1-alpha guarantee, and the smaller bar wins.
+"""
+
+from pathlib import Path
+from typing import Any, Dict
+
+import matplotlib.pyplot as plt
+import numpy as np
+from mapie.classification import CrossConformalClassifier, SplitConformalClassifier
+from xgboost import XGBClassifier
+
+from src.logger import get_logger
+
+logger = get_logger(__name__)
+
+MethodResults = Dict[str, Dict[str, Dict[str, float]]]
+
+
+def _xgb_from_cfg(xgb_cfg: dict[str, Any], seed: int) -> XGBClassifier:
+    """Construct an XGBClassifier from the project config block."""
+    cfg = dict(xgb_cfg)
+    cfg.pop("use_label_encoder", None)  # removed in XGBoost 2.x
+    cfg.pop("random_state", None)
+    cfg.setdefault("eval_metric", "logloss")
+    return XGBClassifier(
+        n_estimators=int(cfg.pop("n_estimators", 200)),
+        max_depth=int(cfg.pop("max_depth", 4)),
+        learning_rate=float(cfg.pop("learning_rate", 0.05)),
+        random_state=seed,
+        **cfg,
+    )
+
+
+def _score_split(
+    scc: SplitConformalClassifier,
+    X_test: np.ndarray,
+    y_test: np.ndarray,
+    alphas: list[float],
+) -> dict[str, dict[str, float]]:
+    """Score a fitted SplitConformalClassifier on (X_test, y_test) for each alpha."""
+    metrics: dict[str, dict[str, float]] = {}
+    _, y_set_all = scc.predict_set(X_test)
+    n = int(len(y_test))
+    for idx, alpha in enumerate(alphas):
+        y_set = y_set_all[:, :, idx]
+        covered = float(y_set[np.arange(n), y_test].sum() / n)
+        sizes = y_set.sum(axis=1)
+        metrics[str(alpha)] = {
+            "empirical_coverage": covered,
+            "mean_set_size": float(sizes.mean()),
+        }
+    return metrics
+
+
+def _score_cv_plus(
+    estimator: XGBClassifier,
+    X_full: np.ndarray,
+    y_full: np.ndarray,
+    X_test: np.ndarray,
+    y_test: np.ndarray,
+    alphas: list[float],
+    cv: int,
+    seed: int,
+) -> dict[str, dict[str, float]]:
+    """Fit a CrossConformalClassifier (CV+) at the given cv depth and score it."""
+    confidence_levels = [1.0 - a for a in alphas]
+    ccc = CrossConformalClassifier(
+        estimator=estimator,
+        confidence_level=confidence_levels,
+        conformity_score="lac",
+        cv=cv,
+        random_state=seed,
+    )
+    ccc.fit_conformalize(X_full, y_full)
+    _, y_set_all = ccc.predict_set(X_test)
+    n = int(len(y_test))
+    metrics: dict[str, dict[str, float]] = {}
+    for idx, alpha in enumerate(alphas):
+        y_set = y_set_all[:, :, idx]
+        covered = float(y_set[np.arange(n), y_test].sum() / n)
+        sizes = y_set.sum(axis=1)
+        metrics[str(alpha)] = {
+            "empirical_coverage": covered,
+            "mean_set_size": float(sizes.mean()),
+        }
+    return metrics
+
+
+def compare_methods(
+    X_train: np.ndarray,
+    y_train: np.ndarray,
+    X_cal: np.ndarray,
+    y_cal: np.ndarray,
+    X_test: np.ndarray,
+    y_test: np.ndarray,
+    alphas: list[float],
+    xgb_params: dict[str, Any],
+    seed: int,
+) -> MethodResults:
+    """Run Split-CP and two CV+ depths on the same test split.
+
+    Returns a nested dict keyed by ``split_lac`` / ``cv_plus_5`` /
+    ``cv_plus_10``; each entry maps alpha to {empirical_coverage,
+    mean_set_size}. Mirrors the shape of
+    ``coverage.compute_per_alpha_coverage`` so JSON readers handle either
+    output uniformly.
+    """
+    confidence_levels = [1.0 - a for a in alphas]
+    results: MethodResults = {}
+
+    # Split-CP LAC — fit XGB on train, conformalize on cal.
+    xgb_split = _xgb_from_cfg(xgb_params, seed).fit(X_train, y_train)
+    scc_split = SplitConformalClassifier(
+        estimator=xgb_split,
+        confidence_level=confidence_levels,
+        conformity_score="lac",
+        prefit=True,
+    )
+    scc_split.conformalize(X_cal, y_cal)
+    results["split_lac"] = _score_split(scc_split, X_test, y_test, alphas)
+    logger.info("Compared method=split_lac alphas=%s", alphas)
+
+    # Cross-CP / Jackknife+ flavour — fit on train+cal, no prefit.
+    X_full = np.vstack([X_train, X_cal])
+    y_full = np.concatenate([y_train, y_cal])
+    for k, key in ((5, "cv_plus_5"), (10, "cv_plus_10")):
+        xgb_cv = _xgb_from_cfg(xgb_params, seed)
+        results[key] = _score_cv_plus(
+            xgb_cv, X_full, y_full, X_test, y_test, alphas, cv=k, seed=seed
+        )
+        logger.info("Compared method=%s alphas=%s", key, alphas)
+
+    return results
+
+
+def plot_method_comparison(results: MethodResults, out_path: Path) -> None:
+    """Render a 2-panel chart: empirical coverage and mean set size per method."""
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    methods = list(results.keys())
+    alphas_sorted = sorted(next(iter(results.values())).keys(), key=float)
+
+    fig, (ax_cov, ax_size) = plt.subplots(1, 2, figsize=(12, 4.5))
+    width = 0.25
+    x = np.arange(len(alphas_sorted))
+    palette = ["#4f46e5", "#7c3aed", "#0ea5e9"]
+    for i, method in enumerate(methods):
+        cov = [results[method][a]["empirical_coverage"] for a in alphas_sorted]
+        size = [results[method][a]["mean_set_size"] for a in alphas_sorted]
+        offset = (i - (len(methods) - 1) / 2) * width
+        ax_cov.bar(x + offset, cov, width=width, label=method, color=palette[i % 3])
+        ax_size.bar(x + offset, size, width=width, label=method, color=palette[i % 3])
+
+    for ax_idx, ax in enumerate((ax_cov, ax_size)):
+        ax.set_xticks(x)
+        ax.set_xticklabels([f"alpha={a}" for a in alphas_sorted])
+        ax.legend(loc="best")
+        ax.grid(axis="y", linestyle=":", alpha=0.4)
+        if ax_idx == 0:
+            ax.set_ylim(0, 1.05)
+            ax.set_ylabel("Empirical coverage")
+            for j, a in enumerate(alphas_sorted):
+                ax.hlines(
+                    1.0 - float(a),
+                    j - 0.45,
+                    j + 0.45,
+                    colors="#dc2626",
+                    linestyles="dashed",
+                )
+
+    ax_cov.set_title("Coverage by method")
+    ax_size.set_title("Mean set size by method")
+    fig.suptitle("Method comparison: Split CP vs CV+ (k=5, 10) on test split")
+    fig.tight_layout()
+    fig.savefig(out_path, dpi=140)
+    plt.close(fig)
+    logger.info("Wrote method-comparison chart to %s", out_path)

--- a/src/evaluation/mondrian.py
+++ b/src/evaluation/mondrian.py
@@ -1,0 +1,203 @@
+"""Group-conditional (Mondrian) coverage and parity statistical tests.
+
+Marginal conformal coverage is just an average — a model can clear the
+1-alpha guarantee overall while systematically under-covering a subgroup
+(women, elderly, etc.). Mondrian conformal prediction reports per-subgroup
+empirical coverage so that imbalance shows up as a number rather than a
+hidden failure mode.
+
+Two parity tests are reported on top of the per-group numbers:
+
+* **Sex parity** — single chi-squared test on the 2x2 contingency table
+  (covered vs not, sex==0 vs sex==1). p < 0.05 flags coverage that is
+  meaningfully different between sexes.
+* **Age parity (Bonferroni-corrected)** — three age-bin chi-squared tests
+  versus the rest of the cohort (one-vs-rest), p-values multiplied by 3
+  to control family-wise error.
+
+The plot ``group_coverage.png`` shows each subgroup's empirical coverage
+versus the 1 - alpha reference line.
+"""
+
+from pathlib import Path
+from typing import Any, Dict
+
+import matplotlib.pyplot as plt
+import numpy as np
+import pandas as pd
+from scipy.stats import chi2_contingency
+
+from src.logger import get_logger
+from src.models.model import ConformalXGBoost
+
+logger = get_logger(__name__)
+
+GroupResults = Dict[str, Any]
+
+
+def _build_masks(raw_test: pd.DataFrame) -> dict[str, np.ndarray]:
+    """Return boolean masks for the five reportable subgroups."""
+    age = raw_test["age"].astype(int).values
+    sex = raw_test["sex"].astype(int).values
+    return {
+        "sex_0": sex == 0,
+        "sex_1": sex == 1,
+        "age_lt_50": age < 50,
+        "age_50_64": (age >= 50) & (age < 65),
+        "age_65p": age >= 65,
+    }
+
+
+def group_coverage(
+    model: ConformalXGBoost,
+    raw_test: pd.DataFrame,
+    X_test: np.ndarray,
+    alpha: float,
+) -> GroupResults:
+    """Compute empirical coverage per subgroup at the given alpha.
+
+    ``raw_test`` carries the unscaled sex/age columns used to build the
+    Mondrian masks; ``X_test`` is the already-scaled feature matrix that
+    feeds the model. Keeping these separate avoids inverse-transforming
+    the StandardScaler to recover integer demographic columns.
+    """
+    _, y_set = model.safe_predict(X_test, alpha=float(alpha))
+    y_true = raw_test["target"].astype(int).values
+    masks = _build_masks(raw_test)
+    results: GroupResults = {}
+    for name, mask in masks.items():
+        n = int(mask.sum())
+        if n == 0:
+            results[name] = {
+                "n": 0,
+                "empirical_coverage": float("nan"),
+                "mean_set_size": float("nan"),
+            }
+            continue
+        sub_set = y_set[mask]
+        sub_y = y_true[mask]
+        covered = float(sub_set[np.arange(n), sub_y].sum() / n)
+        sizes = sub_set.sum(axis=1)
+        results[name] = {
+            "n": n,
+            "empirical_coverage": covered,
+            "mean_set_size": float(sizes.mean()),
+        }
+        logger.info(
+            "group=%s n=%d coverage=%.3f mean_size=%.2f",
+            name,
+            n,
+            covered,
+            float(sizes.mean()),
+        )
+    results["overall_alpha"] = alpha
+    return results
+
+
+def _covered_indicator(
+    model: ConformalXGBoost,
+    raw_test: pd.DataFrame,
+    X_test: np.ndarray,
+    alpha: float,
+) -> np.ndarray:
+    """Return a binary array of whether each test row's true label was covered."""
+    _, y_set = model.safe_predict(X_test, alpha=float(alpha))
+    y_true = raw_test["target"].astype(int).values
+    n = int(len(y_true))
+    return np.asarray(y_set[np.arange(n), y_true]).astype(int)
+
+
+def parity_test(
+    model: ConformalXGBoost,
+    raw_test: pd.DataFrame,
+    X_test: np.ndarray,
+    alpha: float,
+) -> dict[str, float]:
+    """Sex parity (one chi-squared) plus age parity (3 tests, Bonferroni).
+
+    Returns a dict with ``sex_p_value``, ``age_lt_50_p_value_bonf``,
+    ``age_50_64_p_value_bonf``, ``age_65p_p_value_bonf``. Bonferroni-corrected
+    p-values are capped at 1.0; the family size is the number of age bins (3).
+    """
+    covered = _covered_indicator(model, raw_test, X_test, alpha)
+    masks = _build_masks(raw_test)
+    out: dict[str, float] = {}
+
+    sex_table = np.array(
+        [
+            [
+                int(covered[masks["sex_0"]].sum()),
+                int((1 - covered[masks["sex_0"]]).sum()),
+            ],
+            [
+                int(covered[masks["sex_1"]].sum()),
+                int((1 - covered[masks["sex_1"]]).sum()),
+            ],
+        ]
+    )
+    if sex_table.sum() == 0 or (sex_table.sum(axis=1) == 0).any():
+        out["sex_p_value"] = 1.0
+    else:
+        _, p, _, _ = chi2_contingency(sex_table)
+        out["sex_p_value"] = float(p)
+
+    age_keys = ("age_lt_50", "age_50_64", "age_65p")
+    family = len(age_keys)
+    for key in age_keys:
+        in_mask = masks[key]
+        out_mask = ~in_mask
+        table = np.array(
+            [
+                [
+                    int(covered[in_mask].sum()),
+                    int((1 - covered[in_mask]).sum()),
+                ],
+                [
+                    int(covered[out_mask].sum()),
+                    int((1 - covered[out_mask]).sum()),
+                ],
+            ]
+        )
+        if table.sum() == 0 or (table.sum(axis=1) == 0).any():
+            p_bonf = 1.0
+        else:
+            _, p, _, _ = chi2_contingency(table)
+            p_bonf = min(1.0, float(p) * family)
+        out[f"{key}_p_value_bonf"] = p_bonf
+    return out
+
+
+def plot_group_coverage(results: GroupResults, alpha: float, out_path: Path) -> None:
+    """Render a bar chart of subgroup empirical coverage versus 1 - alpha."""
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    groups = [k for k in results.keys() if k != "overall_alpha" and k != "parity"]
+    cov = [
+        results[g]["empirical_coverage"]
+        for g in groups
+        if not np.isnan(results[g].get("empirical_coverage", np.nan))
+    ]
+    groups = [
+        g for g in groups if not np.isnan(results[g].get("empirical_coverage", np.nan))
+    ]
+    fig, ax = plt.subplots(figsize=(8, 4.5))
+    x = np.arange(len(groups))
+    ax.bar(x, cov, width=0.55, color="#7c3aed")
+    ax.hlines(
+        1.0 - float(alpha),
+        -0.5,
+        len(groups) - 0.5,
+        colors="#dc2626",
+        linestyles="dashed",
+        linewidth=2,
+        label=f"target 1 - alpha = {1 - float(alpha):.2f}",
+    )
+    ax.set_xticks(x)
+    ax.set_xticklabels(groups, rotation=20, ha="right")
+    ax.set_ylim(0, 1.05)
+    ax.set_ylabel("Empirical coverage")
+    ax.set_title(f"Mondrian group coverage at alpha = {alpha}")
+    ax.legend()
+    fig.tight_layout()
+    fig.savefig(out_path, dpi=140)
+    plt.close(fig)
+    logger.info("Wrote group-coverage chart to %s", out_path)

--- a/tests/test_evaluation.py
+++ b/tests/test_evaluation.py
@@ -101,6 +101,39 @@ class TestPerAlphaCoverage:
             ), f"alpha={alpha}: coverage {cov:.3f} below target"
 
 
+class TestMethodComparison:
+    """Split CP vs CV+ (k=5, 10) shape + coverage guarantees.
+
+    APS/RAPS scores are excluded — MAPIE 1.x rejects them at runtime for binary
+    targets (CLAUDE.md C35 + ValueError raised by check_target). We vary the
+    splitting strategy instead, all using the LAC conformity score.
+    """
+
+    def test_method_comparison_three_methods(
+        self, cfg_in_tmp: dict, evaluation_results: dict
+    ) -> None:
+        """results['method_comparison'] has split_lac, cv_plus_5, cv_plus_10."""
+        mc = evaluation_results["method_comparison"]
+        assert set(mc.keys()) == {"split_lac", "cv_plus_5", "cv_plus_10"}
+        for method in mc:
+            for alpha in cfg_in_tmp["training"]["alphas"]:
+                entry = mc[method][str(alpha)]
+                assert "empirical_coverage" in entry
+                assert "mean_set_size" in entry
+
+    def test_method_comparison_meets_coverage(
+        self, cfg_in_tmp: dict, evaluation_results: dict
+    ) -> None:
+        """Every method clears the 1-alpha guarantee within tolerance."""
+        mc = evaluation_results["method_comparison"]
+        for method, per_alpha in mc.items():
+            for alpha_str, entry in per_alpha.items():
+                cov = entry["empirical_coverage"]
+                assert (
+                    cov >= 1 - float(alpha_str) - 0.05
+                ), f"method={method} alpha={alpha_str} coverage={cov:.3f}"
+
+
 class TestArtefacts:
     """Figure artefacts and the merged results.json file."""
 
@@ -118,12 +151,21 @@ class TestArtefacts:
         path = Path(cfg_in_tmp["paths"]["figures_dir"], "set_sizes.png")
         assert path.exists() and path.stat().st_size > 0
 
-    def test_results_json_persists_coverage_key(
+    def test_method_comparison_chart_written(
         self, cfg_in_tmp: dict, evaluation_results: dict
     ) -> None:
-        """reports/results.json contains the coverage block after the run."""
+        """method_comparison_set_sizes.png is written to the figures directory."""
+        path = Path(
+            cfg_in_tmp["paths"]["figures_dir"], "method_comparison_set_sizes.png"
+        )
+        assert path.exists() and path.stat().st_size > 0
+
+    def test_results_json_persists_top_level_keys(
+        self, cfg_in_tmp: dict, evaluation_results: dict
+    ) -> None:
+        """reports/results.json contains every section key emitted so far."""
         path = Path(cfg_in_tmp["paths"]["reports_dir"], "results.json")
         assert path.exists()
         payload = json.loads(path.read_text())
-        assert "coverage" in payload
-        assert isinstance(payload["coverage"], dict)
+        for key in ("coverage", "method_comparison"):
+            assert key in payload, f"missing {key}"

--- a/tests/test_evaluation.py
+++ b/tests/test_evaluation.py
@@ -134,6 +134,30 @@ class TestMethodComparison:
                 ), f"method={method} alpha={alpha_str} coverage={cov:.3f}"
 
 
+class TestMondrianGroupCoverage:
+    """Per-subgroup coverage and parity statistical tests."""
+
+    def test_group_coverage_keys(
+        self, cfg_in_tmp: dict, evaluation_results: dict
+    ) -> None:
+        """The five reportable subgroups appear in results['group_coverage']."""
+        gc = evaluation_results["group_coverage"]
+        for key in ("sex_0", "sex_1", "age_lt_50", "age_50_64", "age_65p"):
+            assert key in gc
+            assert "n" in gc[key]
+            assert "empirical_coverage" in gc[key]
+
+    def test_parity_test_returns_pvalue(
+        self, cfg_in_tmp: dict, evaluation_results: dict
+    ) -> None:
+        """parity dict has a finite sex_p_value in [0, 1]."""
+        parity = evaluation_results["group_coverage"]["parity"]
+        assert "sex_p_value" in parity
+        p = parity["sex_p_value"]
+        assert isinstance(p, float)
+        assert 0.0 <= p <= 1.0
+
+
 class TestArtefacts:
     """Figure artefacts and the merged results.json file."""
 
@@ -160,6 +184,13 @@ class TestArtefacts:
         )
         assert path.exists() and path.stat().st_size > 0
 
+    def test_group_coverage_chart_written(
+        self, cfg_in_tmp: dict, evaluation_results: dict
+    ) -> None:
+        """group_coverage.png is written to the figures directory."""
+        path = Path(cfg_in_tmp["paths"]["figures_dir"], "group_coverage.png")
+        assert path.exists() and path.stat().st_size > 0
+
     def test_results_json_persists_top_level_keys(
         self, cfg_in_tmp: dict, evaluation_results: dict
     ) -> None:
@@ -167,5 +198,5 @@ class TestArtefacts:
         path = Path(cfg_in_tmp["paths"]["reports_dir"], "results.json")
         assert path.exists()
         payload = json.loads(path.read_text())
-        for key in ("coverage", "method_comparison"):
+        for key in ("coverage", "method_comparison", "group_coverage"):
             assert key in payload, f"missing {key}"


### PR DESCRIPTION
Closes #17
Stacked on PR #22.

## Summary
- `src/evaluation/mondrian.py` — per-subgroup empirical coverage and mean set size for sex (0/1) and age (lt 50 / 50-64 / 65+).
- Chi-squared parity test on sex + Bonferroni-corrected age-bin tests via `scipy.stats.chi2_contingency`.
- Bar chart `group_coverage.png` with the 1 - alpha reference line.
- Reuses the same deterministic `three_way_split` to recover unscaled sex/age columns from `data/raw/heart.csv` for grouping; the model still consumes already-scaled features.

## Test plan
- [x] `pytest tests/test_evaluation.py::TestMondrianGroupCoverage -v` (2 cases)
- [x] full local gates green (46 tests, 93% coverage)
- [x] manual run produces `reports/figures/group_coverage.png` and `group_coverage` block in `results.json`