### PR TITLE
Day 4 PR5: Decision Curve Analysis

### DIFF
--- a/src/evaluation/dca.py
+++ b/src/evaluation/dca.py
@@ -1,0 +1,114 @@
+"""Decision Curve Analysis (rule A).
+
+Standard accuracy/AUC scores treat false positives and false negatives as
+equally costly, which is wrong for medical screening: a missed heart-disease
+case (FN) is far worse than a false alarm (FP). DCA expresses both kinds of
+error in the same currency by weighting them through the threshold of
+"willingness to treat" t:
+
+    net_benefit(t) = TP / N - FP / N * (t / (1 - t))
+
+The model is reported alongside two reference strategies:
+
+* **treat-all** — flag every patient. ``net_benefit = prev - (1-prev) * t/(1-t)``.
+* **treat-none** — flag nobody. ``net_benefit = 0``.
+
+A model is clinically useful at threshold t if its curve is above both
+references. The DCA chart in ``reports/figures/dca_net_benefit.png`` shows
+that range at a glance.
+"""
+
+from pathlib import Path
+from typing import Dict, Optional
+
+import matplotlib.pyplot as plt
+import numpy as np
+
+from src.logger import get_logger
+
+logger = get_logger(__name__)
+
+DCAResults = Dict[str, list]
+
+
+def decision_curve_analysis(
+    y_true: np.ndarray,
+    y_proba: np.ndarray,
+    thresholds: Optional[np.ndarray] = None,
+) -> DCAResults:
+    """Return net-benefit curves for the model, treat-all, and treat-none.
+
+    All three curves share the same threshold grid so the plotting layer can
+    line them up without re-keying. ``thresholds`` defaults to a 99-point
+    sweep on (0.01, 0.99); thresholds at the boundary cause a divide-by-zero
+    in ``t / (1 - t)`` and are explicitly excluded.
+    """
+    y_true_arr = np.asarray(y_true).astype(int)
+    y_proba_arr = np.asarray(y_proba).astype(float)
+    n = int(len(y_true_arr))
+    prev = float(y_true_arr.mean())
+
+    if thresholds is None:
+        thresholds = np.arange(0.01, 0.99 + 1e-9, 0.01)
+    t_arr = np.asarray(thresholds).astype(float)
+
+    model_nb: list[float] = []
+    treat_all_nb: list[float] = []
+    treat_none_nb: list[float] = []
+    for t in t_arr:
+        odds = t / max(1.0 - t, 1e-9)
+        y_hat = (y_proba_arr >= t).astype(int)
+        tp = float(((y_hat == 1) & (y_true_arr == 1)).sum())
+        fp = float(((y_hat == 1) & (y_true_arr == 0)).sum())
+        model_nb.append(tp / n - (fp / n) * odds)
+        treat_all_nb.append(prev - (1.0 - prev) * odds)
+        treat_none_nb.append(0.0)
+
+    logger.info(
+        "DCA: thresholds=%d prev=%.3f model peak=%.3f",
+        len(t_arr),
+        prev,
+        max(model_nb) if model_nb else 0.0,
+    )
+    return {
+        "thresholds": t_arr.tolist(),
+        "model": model_nb,
+        "treat_all": treat_all_nb,
+        "treat_none": treat_none_nb,
+        "prevalence": [prev],
+    }
+
+
+def plot_dca(results: DCAResults, out_path: Path) -> None:
+    """Render a line chart of the model versus the two reference strategies."""
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    t = np.asarray(results["thresholds"])
+    fig, ax = plt.subplots(figsize=(8, 5))
+    ax.plot(t, results["model"], color="#4f46e5", linewidth=2.5, label="model")
+    ax.plot(
+        t,
+        results["treat_all"],
+        color="#0ea5e9",
+        linewidth=1.5,
+        linestyle="--",
+        label="treat all",
+    )
+    ax.plot(
+        t,
+        results["treat_none"],
+        color="#dc2626",
+        linewidth=1.5,
+        linestyle=":",
+        label="treat none",
+    )
+    ax.axhline(0, color="black", linewidth=0.5)
+    ax.set_xlabel("Threshold probability (t)")
+    ax.set_ylabel("Net benefit")
+    ax.set_title("Decision Curve Analysis")
+    ax.set_ylim(min(-0.05, min(results["model"])) - 0.02, max(results["model"]) + 0.02)
+    ax.legend(loc="upper right")
+    ax.grid(linestyle=":", alpha=0.4)
+    fig.tight_layout()
+    fig.savefig(out_path, dpi=140)
+    plt.close(fig)
+    logger.info("Wrote DCA chart to %s", out_path)

--- a/src/evaluation/evaluate.py
+++ b/src/evaluation/evaluate.py
@@ -28,6 +28,7 @@ from src.evaluation.coverage import (
     plot_coverage_bar,
     plot_set_sizes_hist,
 )
+from src.evaluation.dca import decision_curve_analysis, plot_dca
 from src.evaluation.ece import expected_calibration_error, plot_reliability_diagram
 from src.evaluation.method_compare import compare_methods, plot_method_comparison
 from src.evaluation.mondrian import group_coverage, parity_test, plot_group_coverage
@@ -113,6 +114,10 @@ def run_evaluation(cfg: dict[str, Any]) -> dict[str, Any]:
     ece, frac_pos, mean_pred = expected_calibration_error(y_test, y_proba, n_bins=10)
     results["ece"] = {"value": float(ece), "n_bins": 10}
     plot_reliability_diagram(frac_pos, mean_pred, ece, figures_dir / "calibration.png")
+
+    # Section E — Decision Curve Analysis (rule A).
+    results["dca"] = decision_curve_analysis(y_test, y_proba)
+    plot_dca(results["dca"], figures_dir / "dca_net_benefit.png")
 
     # Persist — merge into existing reports/results.json so baseline_xgb stays.
     out_path = reports_dir / "results.json"

--- a/tests/test_evaluation.py
+++ b/tests/test_evaluation.py
@@ -171,6 +171,22 @@ class TestExpectedCalibrationError:
         assert ece["n_bins"] == 10
 
 
+class TestDecisionCurveAnalysis:
+    """Net-benefit curves: shape and consistency."""
+
+    def test_dca_three_curves(self, cfg_in_tmp: dict, evaluation_results: dict) -> None:
+        """results['dca'] has model + treat_all + treat_none, all same length."""
+        dca = evaluation_results["dca"]
+        for key in ("model", "treat_all", "treat_none", "thresholds"):
+            assert key in dca
+        n = len(dca["thresholds"])
+        assert len(dca["model"]) == n
+        assert len(dca["treat_all"]) == n
+        assert len(dca["treat_none"]) == n
+        # treat_none is by definition zero everywhere.
+        assert all(v == 0.0 for v in dca["treat_none"])
+
+
 class TestArtefacts:
     """Figure artefacts and the merged results.json file."""
 
@@ -211,6 +227,13 @@ class TestArtefacts:
         path = Path(cfg_in_tmp["paths"]["figures_dir"], "calibration.png")
         assert path.exists() and path.stat().st_size > 0
 
+    def test_dca_chart_written(
+        self, cfg_in_tmp: dict, evaluation_results: dict
+    ) -> None:
+        """dca_net_benefit.png is written to the figures directory."""
+        path = Path(cfg_in_tmp["paths"]["figures_dir"], "dca_net_benefit.png")
+        assert path.exists() and path.stat().st_size > 0
+
     def test_results_json_persists_top_level_keys(
         self, cfg_in_tmp: dict, evaluation_results: dict
     ) -> None:
@@ -218,5 +241,5 @@ class TestArtefacts:
         path = Path(cfg_in_tmp["paths"]["reports_dir"], "results.json")
         assert path.exists()
         payload = json.loads(path.read_text())
-        for key in ("coverage", "method_comparison", "group_coverage", "ece"):
+        for key in ("coverage", "method_comparison", "group_coverage", "ece", "dca"):
             assert key in payload, f"missing {key}"


### PR DESCRIPTION
Closes #19
Stacked on PR #24.

## Summary
- `src/evaluation/dca.py` — net-benefit curves for model vs treat-all vs treat-none across thresholds (0.01..0.99).
- Wires DCA into `evaluate.py`; persists `{thresholds, model, treat_all, treat_none, prevalence}` to `results.json`; renders `dca_net_benefit.png`.

## Why this matters for medical AI
Accuracy treats FN and FP as equally costly. For heart-disease screening they aren't — DCA expresses both error types as a single net-benefit number through the threshold-weighted formula `tp/N - fp/N * t/(1-t)`. The model is clinically useful in the threshold band where its curve sits above both reference strategies.

## Test plan
- [x] new test: `test_dca_three_curves`
- [x] full local gates green (15 evaluation tests, ~92% coverage)