### PR TITLE
feat: Tab 2 — global SHAP beeswarm + bar chart

### DIFF
--- a/app.py
+++ b/app.py
@@ -161,10 +161,18 @@ with tab1:
 # ── Tab 2: Global SHAP beeswarm + bar ───────────────────────────────────────
 with tab2:
     st.subheader("Global feature importance — SHAP beeswarm (rule U1)")
-    st.caption("Computed on the calibration split (n ≈ 60 rows).")
+    st.caption(
+        "Computed on the calibration split (n ≈ 60 rows). "
+        "Red = high feature value, blue = low feature value. "
+        "Horizontal position = SHAP impact on model output."
+    )
 
-    X_cal = scaler.transform(cal.drop(columns=["target"]).values)
-    sv_cal = explainer(X_cal)
+    _cal_features = cal.drop(columns=["target"])
+    _X_cal_df = pd.DataFrame(
+        scaler.transform(_cal_features),
+        columns=_cal_features.columns,
+    )
+    sv_cal = explainer(_X_cal_df)
 
     fig1, _ = plt.subplots(figsize=(8, 5))
     shap.plots.beeswarm(sv_cal, show=False)


### PR DESCRIPTION
## Summary
- Pass calibration split as DataFrame (not numpy array) to scaler so SHAP picks up named features — beeswarm/bar now show 'age', 'sex', 'cp' etc. instead of generic indices
- Fixes sklearn warning: 'X does not have valid feature names, but StandardScaler was fitted with feature names'
- Add beeswarm color legend caption (red = high value, blue = low, horizontal = SHAP impact)

## Test plan
- [x] All 4 streamlit tests pass
- [x] black / flake8 / mypy clean

Closes #36