### PR TITLE
feat: Tab 4 — Mondrian group-conditional fairness + parity p-values

### DIFF
--- a/app.py
+++ b/app.py
@@ -269,6 +269,18 @@ with tab4:
                 pd.DataFrame(rows).set_index("group"), use_container_width=True
             )
 
+    parity = results.get("group_coverage", {}).get("parity", {})
+    if parity:
+        st.subheader("Coverage parity test (Bonferroni-corrected p-values)")
+        st.caption(
+            "p > 0.05 = no statistically significant coverage disparity for that group."
+        )
+        _parity_rows = [{"group_test": k, "p_value": v} for k, v in parity.items()]
+        st.dataframe(
+            pd.DataFrame(_parity_rows).set_index("group_test"),
+            use_container_width=True,
+        )
+
     st.markdown(
         """
 > **Marginal vs conditional coverage:**


### PR DESCRIPTION
## Summary
- Parity test table: Bonferroni-corrected p-values per demographic group, surfaced from \eports/results.json\
- Group coverage DataFrame filtered to skip scalar fields (\overall_alpha\, \parity\)
- EU AI Act Annex III § 1 pedagogy block: marginal vs conditional coverage distinction
- Collapsible APS vs RAPS vs CV+ method comparison with figure + numeric table

## Test plan
- [x] All 62 tests pass, 91.6% coverage
- [x] black / flake8 / mypy clean

Closes #38